### PR TITLE
Fix Setup hanging while scanning capture devices

### DIFF
--- a/data/script/Setup_MSCGUI.ps1
+++ b/data/script/Setup_MSCGUI.ps1
@@ -695,6 +695,10 @@ function Apply-Lang([string]$lang) {
             $lScanStatus.ForeColor = $script:ERROR_C
             $lScanStatus.Text = T "S1NoFfplay"
         }
+        "scan_error" {
+            $lScanStatus.ForeColor = $script:ERROR_C
+            $lScanStatus.Text = [string]::Format((T "ErrStatus"), $script:LastScanError)
+        }
         default { $lScanStatus.Text = "" }
     }
 
@@ -766,12 +770,15 @@ $btnES.Add_Click({
 })
 
 $btnScan.Add_Click({
+    if ($script:LastScanState -eq "scanning") { return }
+    $btnScan.Enabled = $false
+    $btnApply.Enabled = $false
     $script:LastScanState = "scanning"
     $lScanStatus.ForeColor = $script:MUTED
     $lScanStatus.Text = (T "S1Scanning")
     $form.Refresh()
 
-    $tmpFile = [System.IO.Path]::GetTempFileName()
+    $proc = $null
 
     try {
         $ffplayLocal = Join-Path $script:RootDir "ffplay.exe"
@@ -798,12 +805,23 @@ $btnScan.Add_Click({
         $proc.StartInfo = $psi
         [void]$proc.Start()
 
-        $stdout = $proc.StandardOutput.ReadToEnd()
-        $stderr = $proc.StandardError.ReadToEnd()
-        $proc.WaitForExit()
+        # Drain both pipes concurrently: reading stdout first can deadlock
+        # when the device listing fills stderr's pipe buffer.
+        $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+        $stderrTask = $proc.StandardError.ReadToEndAsync()
+        $scanClock = [System.Diagnostics.Stopwatch]::StartNew()
+        while (-not ($proc.HasExited -and $stdoutTask.IsCompleted -and $stderrTask.IsCompleted)) {
+            if ($scanClock.Elapsed.TotalSeconds -ge 15) {
+                throw "Device scan timed out after 15 seconds. Close other capture apps and retry."
+            }
+            [System.Windows.Forms.Application]::DoEvents()
+            if ($form.IsDisposed) { return }
+            Start-Sleep -Milliseconds 25
+        }
+        $stdout = $stdoutTask.GetAwaiter().GetResult()
+        $stderr = $stderrTask.GetAwaiter().GetResult()
 
         $content = ($stdout + "`r`n" + $stderr)
-        [System.IO.File]::WriteAllText($tmpFile, $content, [System.Text.Encoding]::UTF8)
 
         $vD = @()
         $aD = @()
@@ -849,13 +867,21 @@ $btnScan.Add_Click({
         }
     }
     catch {
-        $script:LastScanState = "no_ffplay"
+        $script:LastScanState = "scan_error"
+        $script:LastScanError = $_.Exception.Message
         $script:LastVideoCount = $null; $script:LastAudioCount = $null
         $lScanStatus.ForeColor = $script:ERROR_C
-        $lScanStatus.Text = ((T "S1NoFfplay") + " " + $_.Exception.Message)
+        $lScanStatus.Text = [string]::Format((T "ErrStatus"), $script:LastScanError)
     }
     finally {
-        if (Test-Path $tmpFile) { Remove-Item $tmpFile -Force }
+        if ($null -ne $proc) {
+            try { if (-not $proc.HasExited) { $proc.Kill() } } catch {}
+            $proc.Dispose()
+        }
+        if (-not $form.IsDisposed) {
+            $btnScan.Enabled = $true
+            $btnApply.Enabled = $true
+        }
     }
 })
 


### PR DESCRIPTION
Clicking Scan Devices can leave Setup stuck on "Scanning...". The handler reads stdout to completion before reading stderr, but ffplay writes its device listing to stderr. If that pipe fills, ffplay cannot exit and the stdout read never completes. Both reads also block the UI thread without a timeout.

This change drains stdout and stderr concurrently, pumps WinForms events while waiting, and limits the scan to 15 seconds. Scan and Apply are disabled during enumeration to prevent re-entry. The child process is cleaned up on failure or window closure, and scan failures display their actual error instead of always reporting that ffplay is missing. The unused temporary output file is removed.

Validation on Windows PowerShell 5.1:
- Parsed the modified script without errors.
- Executed the upstream scan handler with WinForms controls and the installed ffplay: completed with 11 video and 6 audio devices, including USB3.0 Capture and Digital Audio Interface (USB3.0 Capture).
- Checked the missing-executable path: reports a scan error and re-enables Scan and Apply.
- git diff --check passed.

The handler was exercised without displaying the full Setup window. The 15-second timeout and window-close paths have not been manually tested.